### PR TITLE
The sphinx directive arugment implementation in the previous

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -2,6 +2,13 @@
 Change Log
 ===================
 
+0.0.10
+======
+
+The sphinx directive arugment implementation in the previous
+version was not robust enough to real data.  Changed to
+inputing arguments as YAML in the body of the directive.
+
 0.0.9
 ======
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(here, 'requirements.txt'), 'r', encoding='utf-8') as f:
 setup(
     name='sphinx-webslides-builder',
 
-    version='0.0.9',
+    version='0.0.10',
 
     description='sphinx builder that outputs webslides',
 

--- a/sphinx_webslides_builder/template.py
+++ b/sphinx_webslides_builder/template.py
@@ -4,35 +4,35 @@ from docutils.parsers.rst import directives
 from docutils.statemachine import ViewList
 from sphinx.writers.html import HTMLTranslator
 import jinja2
+import yaml
 
 environment = jinja2.Environment()
 
 TD = 'template_definitions'
+
+class template_node(nodes.Element): pass
 
 class TemplateDefinitionDirective(SphinxDirective):
     required_arguments = 1
     has_content = True
 
     def run(self):
-        if TD not in self.env.app.config:
+        try:
+            len(self.env.app.config[TD])
+        except AttributeError:
             self.env.app.config[TD] = {}
         self.env.app.config[TD][self.arguments[0]] = self.content.data
         return []
 
 class TemplateExecuteDirective(SphinxDirective):
     required_arguments = 1
-    optional_arguments = 10
+    has_content = True
 
     def run(self):
-        template_parts = []
-        index = 0
-        while ':' not in self.arguments[index]:
-            template_parts.append(self.arguments[index])
-            index += 1
-        option_data = {self.arguments[i].replace(':', ''): self.arguments[i+1] for i in range(index, len(self.arguments), 2)}
+        option_data = yaml.safe_load('\n'.join(self.content.data))
 
         rendered_content = []
-        for template_line in self.env.app.config[TD][' '.join(template_parts)]:
+        for template_line in self.env.app.config[TD][self.arguments[0]]:
             template = environment.from_string(template_line)
             rendered_content.append(template.render(**option_data))
 
@@ -40,7 +40,7 @@ class TemplateExecuteDirective(SphinxDirective):
         
 
     def _process_content(self, content):        
-        par = nodes.container()
+        par = template_node()
         self.state.nested_parse(
             ViewList(content, 'populated_template'), 
             self.content_offset, par
@@ -56,3 +56,11 @@ def setup_template(app):
     app.add_directive('template-define', TemplateDefinitionDirective)
     app.add_directive('template', TemplateExecuteDirective)
     app.connect('source-read', clear_templates)
+
+class TemplateTranslator(HTMLTranslator):
+    
+    def visit_template_node(self, node):
+        pass
+
+    def depart_template_node(self, node):
+        pass

--- a/sphinx_webslides_builder/webslides_writer.py
+++ b/sphinx_webslides_builder/webslides_writer.py
@@ -16,6 +16,7 @@ from .figure import FigureTranslator
 from .web import WebTranslator
 from .video import VideoTranslator
 from .blockquote import BlockquoteTranslator
+from .template import TemplateTranslator
 
 class WebslidesTranslator(
     SlideTranslator,
@@ -34,6 +35,7 @@ class WebslidesTranslator(
     WebTranslator,
     VideoTranslator,
     BlockquoteTranslator,
+    TemplateTranslator,
 ):
 
     def visit_section(self, node):


### PR DESCRIPTION
version was not robust enough to real data.  Changed to
inputing arguments as YAML in the body of the directive.