### PR TITLE
Fixed bug in the template rendering.  Method did not allow jinja

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -2,6 +2,18 @@
 Change Log
 ===================
 
+0.0.15
+=======
+
+Fixed bug in the template rendering.  Method did not allow jinja
+commands that span lines, e.g. typical multiline if statements
+
+.. code-block:: rst
+
+    {% if True %}
+        Do one thing
+    {% endif %}
+
 0.0.14
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(here, 'requirements.txt'), 'r', encoding='utf-8') as f:
 setup(
     name='sphinx-webslides-builder',
 
-    version='0.0.14',
+    version='0.0.15',
 
     description='sphinx builder that outputs webslides',
 

--- a/sphinx_webslides_builder/template.py
+++ b/sphinx_webslides_builder/template.py
@@ -34,14 +34,18 @@ class TemplateExecuteDirective(SphinxDirective):
 
     def run(self):
         
-        rendered_content = []
+        rendered_content = None
         if 'content_mode' not in self.options:
             defined_input = '\n'.join(self.content.data)
             option_data = yaml.safe_load(defined_input)
-            for template_line in self.env.app.config[TD][self.arguments[0]]:
-                template = environment.from_string(template_line)
-                rendered_content.append(template.render(**option_data))
+            #for template_line in self.env.app.config[TD][self.arguments[0]]:
+            #    template = environment.from_string(template_line)
+            #    rendered_content.append(template.render(**option_data))
+            rendered_content = environment.from_string(
+                '\n'.join(self.env.app.config[TD][self.arguments[0]])
+            ).render(**option_data).split('\n')
         else:
+            rendered_content = []
             for template_line in self.env.app.config[TD][self.arguments[0]]:
                 if '{{' in template_line and 'content' in template_line.lower() and '}}' in template_line:
                     char_index = 0


### PR DESCRIPTION
commands that span lines, e.g. typical multiline if statements